### PR TITLE
Update url

### DIFF
--- a/pyeight/constants.py
+++ b/pyeight/constants.py
@@ -12,7 +12,7 @@ SUB_MINOR_VERSION = 1
 __version__ = '{}.{}.{}'.format(
     MAJOR_VERSION, MINOR_VERSION, SUB_MINOR_VERSION)
 
-API_URL = 'https://app-api.8slp.net/v1'
+API_URL = 'https://client-api.8slp.net/v1'
 
 DEFAULT_TIMEOUT = 60
 
@@ -22,5 +22,5 @@ DEFAULT_HEADERS = {
     'user-agent': "okhttp/3.6.0",
     'accept-encoding': "gzip",
     'accept': "*/*",
-    'authority': "app-api.8slp.net",
+    'authority': "client-api.8slp.net",
     }


### PR DESCRIPTION
EightSleep has changed the API route URL for retrieving client information:
"app-api.8slp.net" -> "client-api.8slp.net"