### PR TITLE
Some cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Special thanks to github user @alyc100 for making his SmartThings Eight Sleep co
 
 # Requirements
 
-* python >= 3.5
+* python >= 3.7
 * aiohttp >= 2.0
 * asyncio
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Basic Usage
 ```python
 from pyeight.eight import EightSleep
 
-eight = EightSleep(user, pass, timezone, True, None, loop)
+eight = EightSleep(user, pass, timezone, None, None)
 
 await eight.start()
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Basic Usage
 ```python
 from pyeight.eight import EightSleep
 
-eight = EightSleep(user, pass, timezone, None, None)
+eight = EightSleep(user, pass, timezone, None)
 
 await eight.start()
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Special thanks to github user @alyc100 for making his SmartThings Eight Sleep co
 * python >= 3.5
 * aiohttp >= 2.0
 * asyncio
-* async_timeout
 
 # Installation
 

--- a/pyeight/constants.py
+++ b/pyeight/constants.py
@@ -8,7 +8,7 @@ Licensed under the MIT license.
 
 MAJOR_VERSION = 0
 MINOR_VERSION = 1
-SUB_MINOR_VERSION = 5
+SUB_MINOR_VERSION = 6
 __version__ = '{}.{}.{}'.format(
     MAJOR_VERSION, MINOR_VERSION, SUB_MINOR_VERSION)
 

--- a/pyeight/eight.py
+++ b/pyeight/eight.py
@@ -22,11 +22,10 @@ _LOGGER = logging.getLogger(__name__)
 
 class EightSleep(object):
     """Eight sleep API object."""
-    def __init__(self, email, password, tzone, api_key=None, client_session=None):
+    def __init__(self, email, password, tzone, client_session=None):
         """Initialize eight sleep class."""
         self._email = email
         self._password = password
-        self._api_key = api_key
 
         self.tzone = tzone
 

--- a/pyeight/eight.py
+++ b/pyeight/eight.py
@@ -155,25 +155,18 @@ class EightSleep(object):
         if data is None:
             _LOGGER.error('Unable to assign eight device users.')
         else:
-            # Find the side to the known userid
-            if data['result']['rightUserId'] == self._userid:
+            # Populate users
+            if data['result'].get('rightUserId'):
                 self.users[data['result']['rightUserId']] = \
                     EightUser(self, data['result']['rightUserId'], 'right')
-                user_side = 'right'
-            elif data['result']['leftUserId'] == self._userid:
-                self.users[data['result']['leftUserId']] = \
-                    EightUser(self, data['result']['leftUserId'], 'left')
-                user_side = 'left'
-            else:
-                _LOGGER.error('Unable to assign eight device users.')
-
-            if self._partner:
-                if user_side == 'right':
+            
+            # Check if there's one user
+            if data['result'].get('leftUserId') and data['result']['leftUserId'] not in self.users:
                     self.users[data['result']['leftUserId']] = \
                         EightUser(self, data['result']['leftUserId'], 'left')
-                else:
-                    self.users[data['result']['rightUserId']] = \
-                        EightUser(self, data['result']['rightUserId'], 'right')
+            
+            if not self.users:
+                _LOGGER.error('Unable to assign eight device users.')
 
     def room_temperature(self):
         """Return room temperature for both sides of bed."""

--- a/pyeight/eight.py
+++ b/pyeight/eight.py
@@ -22,12 +22,10 @@ _LOGGER = logging.getLogger(__name__)
 
 class EightSleep(object):
     """Eight sleep API object."""
-    def __init__(self, email, password, tzone, partner=False, api_key=None,
-                 loop=None, client_session=None):
+    def __init__(self, email, password, tzone, api_key=None, client_session=None):
         """Initialize eight sleep class."""
         self._email = email
         self._password = password
-        self._partner = partner
         self._api_key = api_key
 
         self.tzone = tzone
@@ -164,12 +162,15 @@ class EightSleep(object):
             if data['result'].get('rightUserId'):
                 self.users[data['result']['rightUserId']] = \
                     EightUser(self, data['result']['rightUserId'], 'right')
-            
+
             # Check if there's one user
-            if data['result'].get('leftUserId') and data['result']['leftUserId'] not in self.users:
-                    self.users[data['result']['leftUserId']] = \
-                        EightUser(self, data['result']['leftUserId'], 'left')
-            
+            if (
+                data['result'].get('leftUserId')
+                and data['result']['leftUserId'] not in self.users
+            ):
+                self.users[data['result']['leftUserId']] = \
+                    EightUser(self, data['result']['leftUserId'], 'left')
+
             if not self.users:
                 _LOGGER.error('Unable to assign eight device users.')
 
@@ -227,7 +228,11 @@ class EightSleep(object):
         post = None
         try:
             post = await self._api_session.post(
-                url, params=params, data=data, timeout=ClientTimeout(total=DEFAULT_TIMEOUT))
+                url,
+                params=params,
+                data=data,
+                timeout=ClientTimeout(total=DEFAULT_TIMEOUT)
+            )
             if post.status != 200:
                 _LOGGER.error('Error posting Eight data: %s', post.status)
                 return None
@@ -253,7 +258,11 @@ class EightSleep(object):
 
         try:
             request = await self._api_session.get(
-                url, headers=headers, params=params, timeout=ClientTimeout(total=DEFAULT_TIMEOUT))
+                url,
+                headers=headers,
+                params=params,
+                timeout=ClientTimeout(total=DEFAULT_TIMEOUT)
+            )
             # _LOGGER.debug('Get URL: %s', request.url)
             if request.status != 200:
                 _LOGGER.error('Error fetching Eight data: %s', request.status)
@@ -280,7 +289,11 @@ class EightSleep(object):
 
         try:
             put = await self._api_session.put(
-                url, headers=headers, data=data, timeout=ClientTimeout(total=DEFAULT_TIMEOUT))
+                url,
+                headers=headers,
+                data=data,
+                timeout=ClientTimeout(total=DEFAULT_TIMEOUT)
+            )
             if put.status != 200:
                 _LOGGER.error('Error putting Eight data: %s', put.status)
                 return None

--- a/pyeight/eight.py
+++ b/pyeight/eight.py
@@ -42,12 +42,9 @@ class EightSleep(object):
                              None, None, None, None, None]
 
         self._api_session = client_session
-        if self._api_session:
-            self._internal_session = False
-        else:
-            self._internal_session = True
-            # Stop on exit
-            atexit.register(asyncio.run, self.stop())
+        self._internal_session = False
+        # Stop on exit
+        atexit.register(asyncio.run, self.stop())
 
     @property
     def token(self):
@@ -96,6 +93,7 @@ class EightSleep(object):
         _LOGGER.debug('Initializing pyEight Version: %s', __version__)
         if not self._api_session:
             self._api_session = ClientSession(headers=DEFAULT_HEADERS)
+            self._internal_session = True
 
         await self.fetch_token()
         if self._token is not None:

--- a/pyeight/eight.py
+++ b/pyeight/eight.py
@@ -41,9 +41,8 @@ class EightSleep(object):
         self._device_json = [None, None, None, None, None,
                              None, None, None, None, None]
 
-        self._api_session = None
-        if client_session:
-            self._api_session = client_session
+        self._api_session = client_session
+        if self._api_session:
             self._internal_session = False
         else:
             self._internal_session = True

--- a/pyeight/eight.py
+++ b/pyeight/eight.py
@@ -51,7 +51,7 @@ class EightSleep(object):
         else:
             self._internal_session = True
             # Stop on exit
-            atexit.register(asyncio.run(self.stop()))
+            atexit.register(asyncio.run, self.stop())
 
     @property
     def token(self):

--- a/pyeight/eight.py
+++ b/pyeight/eight.py
@@ -11,8 +11,7 @@ import logging
 import asyncio
 from datetime import datetime
 import time
-import aiohttp
-from aiohttp.client import ClientTimeout
+from aiohttp.client import ClientError, ClientSession, ClientTimeout
 
 from pyeight.user import EightUser
 from pyeight.constants import (
@@ -58,7 +57,7 @@ class EightSleep(object):
             self._api_session = client_session
             self._internal_session = False
         else:
-            self._api_session = aiohttp.ClientSession(
+            self._api_session = ClientSession(
                 headers=DEFAULT_HEADERS, loop=self._event_loop)
             self._internal_session = True
 
@@ -243,7 +242,7 @@ class EightSleep(object):
 
             return post_result
 
-        except (aiohttp.ClientError, asyncio.TimeoutError,
+        except (ClientError, asyncio.TimeoutError,
                 ConnectionRefusedError) as err:
             _LOGGER.error('Error posting Eight data. %s', err)
             return None
@@ -270,7 +269,7 @@ class EightSleep(object):
 
             return request_json
 
-        except (aiohttp.ClientError, asyncio.TimeoutError,
+        except (ClientError, asyncio.TimeoutError,
                 ConnectionRefusedError) as err:
             _LOGGER.error('Error fetching Eight data. %s', err)
             return None
@@ -296,7 +295,7 @@ class EightSleep(object):
 
             return put_result
 
-        except (aiohttp.ClientError, asyncio.TimeoutError,
+        except (ClientError, asyncio.TimeoutError,
                 ConnectionRefusedError) as err:
             _LOGGER.error('Error putting Eight data. %s', err)
             return None

--- a/pyeight/eight.py
+++ b/pyeight/eight.py
@@ -112,13 +112,12 @@ class EightSleep(object):
 
     async def stop(self):
         """Stop api session."""
-        if self._internal_session:
-            if self._api_session:
-                _LOGGER.debug('Closing eight sleep api session.')
-                await self._api_session.close()
-                self._api_session = None
-            else:
-                _LOGGER.debug("No-op because session hasn't been created")
+        if self._internal_session and self._api_session:
+            _LOGGER.debug('Closing eight sleep api session.')
+            await self._api_session.close()
+            self._api_session = None
+        elif self._internal_session:
+            _LOGGER.debug("No-op because session hasn't been created")
         else:
             _LOGGER.debug('No-op because session is being managed outside of pyEight')
 

--- a/pyeight/eight.py
+++ b/pyeight/eight.py
@@ -19,6 +19,8 @@ from pyeight.constants import (
 
 _LOGGER = logging.getLogger(__name__)
 
+CLIENT_TIMEOUT = ClientTimeout(total=DEFAULT_TIMEOUT)
+
 
 class EightSleep(object):
     """Eight sleep API object."""
@@ -224,11 +226,7 @@ class EightSleep(object):
         post = None
         try:
             post = await self._api_session.post(
-                url,
-                params=params,
-                data=data,
-                timeout=ClientTimeout(total=DEFAULT_TIMEOUT)
-            )
+                url, params=params, data=data, timeout=CLIENT_TIMEOUT)
             if post.status != 200:
                 _LOGGER.error('Error posting Eight data: %s', post.status)
                 return None
@@ -254,11 +252,7 @@ class EightSleep(object):
 
         try:
             request = await self._api_session.get(
-                url,
-                headers=headers,
-                params=params,
-                timeout=ClientTimeout(total=DEFAULT_TIMEOUT)
-            )
+                url, headers=headers, params=params, timeout=CLIENT_TIMEOUT)
             # _LOGGER.debug('Get URL: %s', request.url)
             if request.status != 200:
                 _LOGGER.error('Error fetching Eight data: %s', request.status)
@@ -285,11 +279,7 @@ class EightSleep(object):
 
         try:
             put = await self._api_session.put(
-                url,
-                headers=headers,
-                data=data,
-                timeout=ClientTimeout(total=DEFAULT_TIMEOUT)
-            )
+                url, headers=headers, data=data, timeout=CLIENT_TIMEOUT)
             if put.status != 200:
                 _LOGGER.error('Error putting Eight data: %s', put.status)
                 return None

--- a/pyeight/user.py
+++ b/pyeight/user.py
@@ -12,7 +12,6 @@ from datetime import datetime
 from datetime import timedelta
 import statistics
 import time
-import asyncio
 
 from pyeight.constants import (API_URL)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [metadata]
 description-file = README.md
+
+[options]
+python_requires = >= 3.7

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from distutils.core import setup
 setup(
     name='pyEight',
     packages=['pyeight'],
-    version='0.1.5',
+    version='0.1.6',
     description='Provides a python api to interact with an Eight Sleep mattress cover.',
     author='John Mihalic',
     author_email='mezz64@users.noreply.github.com',

--- a/setup.py
+++ b/setup.py
@@ -25,4 +25,5 @@ setup(
     keywords=['eight', 'eightsleep', 'eight sleep', 'sleep', 'mattress', 'api wrapper', 'homeassistant'],
     license='MIT',
     classifiers=[],
+    install_requires=["aiohttp"],
     )


### PR DESCRIPTION
Made a couple of changes:
1. There's no need for the `partner` flag. We can simply check if there is a right user and then if there is a left user that isn't the same as the right user. I think the end result of this is the same... I guess you lose the ability to not include your partner as a user, but I am not sure if that's a common use case.
2. Added support for getting the client session from HA instead of generating it on our own 
3. Removed the `async_timeout` dependency because you can pass the timeout directly to the get/put/post with current versions of `aiohttp`.
4. Removed `loop` as an input. I don't think we need to set the event loop, HA will do that for us, and because of the other changes, it's not needed as an input elsewhere.
5. Made it so that if the client session is created internally by the library, it will get closed automatically on shutdown. I wrote this so that you can safely call stop() multiple times.
6. Removed `api_key` since it is not used anywhere
7. Added `aiohttp` as a dependency so that users outside of HA can use the package

I have done some brief testing, and things appear to be working as expected. Assuming you are OK with these changes and can cut a new release, I'd be happy to make the corresponding changes in HA since this is a breaking change that I am introducing. I will also likely pick up https://github.com/home-assistant/core/pull/47493 at some point to try to get that over the finish line

EDIT: Just found this comment on Discord, so it seems we are on the same page for item 1 🙂  https://discord.com/channels/330944238910963714/330990195199442944/817744252058337330