### PR TITLE
Allow auth data to be passed in to client constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
+.mypy_cache/

--- a/pyeight/eight.py
+++ b/pyeight/eight.py
@@ -153,13 +153,17 @@ class EightSleep:
         else:
             _LOGGER.debug("No-op because session is being managed outside of pyEight")
 
-    async def fetch_token(self) -> None:
+    async def fetch_token(
+        self, return_auth_data: bool = False
+    ) -> dict[str, str] | None:
         """Fetch new session token from api."""
         url = f"{API_URL}/login"
         payload = {"email": self._email, "password": self._password}
 
         reg = await self.api_request("post", url, data=payload, include_token=False)
         self._configure_auth(reg["session"])
+        if return_auth_data:
+            return reg["session"]
         _LOGGER.debug("UserID: %s, Token: %s", self._user_id, self.token)
 
     async def fetch_device_list(self) -> None:

--- a/pyeight/eight.py
+++ b/pyeight/eight.py
@@ -153,18 +153,15 @@ class EightSleep:
         else:
             _LOGGER.debug("No-op because session is being managed outside of pyEight")
 
-    async def fetch_token(
-        self, return_auth_data: bool = False
-    ) -> dict[str, str] | None:
+    async def fetch_token(self) -> dict[str, str]:
         """Fetch new session token from api."""
         url = f"{API_URL}/login"
         payload = {"email": self._email, "password": self._password}
 
         reg = await self.api_request("post", url, data=payload, include_token=False)
         self._configure_auth(reg["session"])
-        if return_auth_data:
-            return reg["session"]
         _LOGGER.debug("UserID: %s, Token: %s", self._user_id, self.token)
+        return reg["session"]
 
     async def fetch_device_list(self) -> None:
         """Fetch list of devices."""

--- a/pyeight/user.py
+++ b/pyeight/user.py
@@ -672,7 +672,7 @@ class EightUser:  # pylint: disable=too-many-public-methods
         """Update trends data json for specified time period."""
         url = f"{API_URL}/users/{self.user_id}/trends"
         params = {
-            "tz": self.device.tzone,
+            "tz": self.device.timezone,
             "from": start_date,
             "to": end_date,
             # 'include-main': 'true'


### PR DESCRIPTION
While working on https://github.com/home-assistant/core/pull/71095 I learned that if you request a token twice in a row in quick succession, you will get rate limited. As a result we have to sleep for five seconds so we can authenticate twice. If we allow the data we retrieve on the first request to be passed in to the client constructor though, we can avoid the second call and don't have to `sleep`.